### PR TITLE
fix: correct names for secrets used by TfLint

### DIFF
--- a/.github/workflows/terraform_module_terraform_callable.yml
+++ b/.github/workflows/terraform_module_terraform_callable.yml
@@ -57,9 +57,9 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: ${{ secrets.AWS_TFLINT_ROLE_ARN }}
+          role-to-assume: ${{ secrets.TFLINT_ROLE_ARN }}
           role-session-name: tflint
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.TFLINT_AWS_REGION }}
 
       - name: install tflint
         run: |

--- a/.github/workflows/terraform_module_terraform_callable.yml
+++ b/.github/workflows/terraform_module_terraform_callable.yml
@@ -6,9 +6,9 @@ on:
   # USE_WORKFLOW
   workflow_call:
     secrets:
-      AWS_TFLINT_ROLE_ARN:
+      TFLINT_ROLE_ARN:
         required: true
-      AWS_REGION:
+      TFLINT_AWS_REGION:
         required: true
 # /USE_WORKFLOW
 # USE_REPOSITORY


### PR DESCRIPTION
# Description

Correct the names of the secrets needed by TfLint. The projects automatically have access to `TFLINT_ROLE_ARN` and `TFLINT_AWS_REGION`. Using non-existing secrets ends with `Secret AWS_TFLINT_ROLE_ARN is required, but not provided while calling.`

# Verification

Copy & paste of the secret names from the settings page.