### PR TITLE
ci: remove version prefix for TfLint installation

### DIFF
--- a/.github/workflows/terraform_module_terraform_callable.yml
+++ b/.github/workflows/terraform_module_terraform_callable.yml
@@ -67,7 +67,7 @@ jobs:
           tflint_version="v0.50.3"
 
           curl -o tflint.zip -L \
-            https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip
+            https://github.com/terraform-linters/tflint/releases/download/${tflint_version}/tflint_linux_amd64.zip
           unzip tflint.zip
 
       - name: Show version


### PR DESCRIPTION
# Description

TfLint can't be installed in the workflow as the version number contains the `v` prefix which was added manually before. We simply remove the prefix here.

```
tflint_version="v0.50.3"
  
  curl -o tflint.zip -L \
    [https://github.com/terraform-linters/tflint/releases/download/v${tflint_version}/tflint_linux_amd64.zip](https://github.com/terraform-linters/tflint/releases/download/v$%7Btflint_version%7D/tflint_linux_amd64.zip)

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100     9  100     9    0     0     77      0 --:--:-- --:--:-- --:--:--    78
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
Archive:  tflint.zip
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
```

# Verification

Verified in https://github.com/Hapag-Lloyd/Repository-Template-Terraform-Module/pull/2
