### PR TITLE
fix: only comment welcome message on non-bot user PRs

### DIFF
--- a/.github/workflows/default_welcome_message_callable.yml
+++ b/.github/workflows/default_welcome_message_callable.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   welcome-message:
+    if: endsWith(github.actor, '[bot]') == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -27,6 +28,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Hey @${{ github.event.pull_request.user.login }}! 👋\n\nThank you for your contribution to the project. Please refer to the [contribution rules](../blob/main/.github/CONTRIBUTING.md) for a quick overview of the process.\n\nMake sure that this PR clearly explains:\n\n- the problem being solved\n- the best way a reviewer and you can test your changes\n\nWith submitting this PR you confirm that you hold the rights of the code added and agree that it will published under this [LICENSE](../blob/main/LICENSE).\n\nThe following ChatOps commands are supported:\n- `/help`: notifies a maintainer to help you out\n\nSimply add a comment with the command in the first line. If you need to pass more information, separate it with a blank line from the command.\n\n_This message was generated automatically. You are welcome to [improve it](https://github.com/Hapag-Lloyd/test/blob/main/.github/workflows/default_welcome_message_callable.yml)._'
+              body: 'Hey @${{ github.event.pull_request.user.login }}! 👋\n\nThank you for your contribution to the project. Please refer to the [contribution rules](../blob/main/.github/CONTRIBUTING.md) for a quick overview of the process.\n\nMake sure that this PR clearly explains:\n\n- the problem being solved\n- the best way a reviewer and you can test your changes\n\nWith submitting this PR you confirm that you hold the rights of the code added and agree that it will published under this [LICENSE](../blob/main/LICENSE).\n\nThe following ChatOps commands are supported:\n- `/help`: notifies a maintainer to help you out\n\nSimply add a comment with the command in the first line. If you need to pass more information, separate it with a blank line from the command.\n\n_This message was generated automatically. You are welcome to [improve it](https://github.com/Hapag-Lloyd/Workflow-Templates/blob/main/.github/workflows/default_welcome_message_callable.yml)._'
             })
           # yamllint enable rule:line-length

--- a/.github/workflows/default_welcome_message_callable.yml
+++ b/.github/workflows/default_welcome_message_callable.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   welcome-message:
-    if: endsWith(github.actor, '[bot]') == false
+    if: ${{ ! endsWith(github.actor, '[bot]') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
# Description

Currently, the welcome message is commented to every PR, even ones that were opened by renovate. The message itself does not make sense on PRs opened by bots and this PR fixes that behavior.

It also fixes a link at the end of the message to the location of the workflow file that generated the message.

# Verification

None.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
