### PR TITLE
fix: read the release-type parameter when updating the workflows

### DIFF
--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -62,7 +62,8 @@ function ensure_and_set_parameters_or_exit() {
   while [[ $# -gt 0 ]]; do
     case $1 in
       --release-type)
-        release_type=$1
+        release_type=$2
+        shift
         shift
         ;;
       --*|-*)


### PR DESCRIPTION
# Description

The script didn't consume the release type which is following the `--release-type` parameter. Thus it always failed if the parameter was given.

# Verification

Tested locally.