### PR TITLE
fix: find the nearest tag for workflow updates

### DIFF
--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -141,7 +141,7 @@ do
 
   # add a reference to this repository which holds the workflow
   commit_sha=$(git rev-parse HEAD)
-  tag=$(git describe --tags $(git rev-list --tags --max-count=1) || true)
+  tag=$(git describe --tags "$(git rev-list --tags --max-count=1)" || true)
 
   file_to_include="uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/$base_name@$commit_sha # $tag"
 

--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -141,7 +141,7 @@ do
 
   # add a reference to this repository which holds the workflow
   commit_sha=$(git rev-parse HEAD)
-  tag=$(git describe --tags --exact-match 2>/dev/null || true)
+  tag=$(git describe --tags $(git rev-list --tags --max-count=1) || true)
 
   file_to_include="uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/$base_name@$commit_sha # $tag"
 


### PR DESCRIPTION
# Description

The `head` of the default branch might not be tagged, i.e. `ci` commit, ... We now find the latest tag in the commit history to be able to create the comment when updating the workflows.

# Verification

Locally.