### PR TITLE
fix: create the PR according to our own standards

### DIFF
--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -61,6 +61,8 @@ function create_commit_and_pr() {
 
     Done by the workflows in this feature branch, except for the release workflow.
 EOF
+  )
+  
   gh pr create --title "ci: update workflows to latest version" --body "" --base main
   gh pr view --web
 }

--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -52,6 +52,15 @@ function create_commit_and_pr() {
   git commit -m "update workflows to latest version"
   git push --set-upstream origin update-workflows
 
+  body=$(cat <<-EOF
+    # Description
+
+    This PR updates all workflows to the latest version.
+
+    # Verification
+
+    Done by the workflows in this feature branch, except for the release workflow.
+EOF
   gh pr create --title "ci: update workflows to latest version" --body "" --base main
   gh pr view --web
 }

--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -63,7 +63,7 @@ function create_commit_and_pr() {
 EOF
   )
   
-  gh pr create --title "ci: update workflows to latest version" --body "" --base main
+  gh pr create --title "ci: update workflows to latest version" --body "$body" --base main
   gh pr view --web
 }
 


### PR DESCRIPTION
# Description

When we update the workflows with `update_workflows.sh` a PR is automatically created. But the description of it didn't follow our own template. This PR adds a multiline description with `Description` and `Verification` section.

# Verification

None.