### PR TITLE
fix: check added or modified Json files only

### DIFF
--- a/.github/workflows/default_linter_callable.yml
+++ b/.github/workflows/default_linter_callable.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           INCLUDE_FILES: ${{ needs.find-changes.outputs.json_files }}
         run: |
-          INCLUDE_FILES=$(echo $INCLUDE_FILES | jq -r '. | join(",")')
+          INCLUDE_FILES=$(echo "$INCLUDE_FILES" | jq -r '. | join(",")')
           bash <(curl -s https://raw.githubusercontent.com/CICDToolbox/json-lint/master/pipeline.sh)
 
   lint-renovate:

--- a/.github/workflows/default_linter_callable.yml
+++ b/.github/workflows/default_linter_callable.yml
@@ -123,7 +123,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run JSON Lint
-        run: bash <(curl -s https://raw.githubusercontent.com/CICDToolbox/json-lint/master/pipeline.sh)
+        env:
+          INCLUDE_FILES: ${{ needs.find-changes.outputs.json_files }}
+        run: |
+          INCLUDE_FILES=$(echo $INCLUDE_FILES | jq -r '. | join(",")')
+          bash <(curl -s https://raw.githubusercontent.com/CICDToolbox/json-lint/master/pipeline.sh)
 
   lint-renovate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

Configures the Json linter to use the specified files only. Otherwise all Json files are checked, including Json5, which does not work.

# Verification

Job manually tested in the test repository.