### PR TITLE
fix: remove indentation from PR text

### DIFF
--- a/update-workflows.sh
+++ b/update-workflows.sh
@@ -52,14 +52,14 @@ function create_commit_and_pr() {
   git commit -m "update workflows to latest version"
   git push --set-upstream origin update-workflows
 
-  body=$(cat <<-EOF
-    # Description
+  body=$(cat <<EOF
+# Description
 
-    This PR updates all workflows to the latest version.
+This PR updates all workflows to the latest version.
 
-    # Verification
+# Verification
 
-    Done by the workflows in this feature branch, except for the release workflow.
+Done by the workflows in this feature branch, except for the release workflow.
 EOF
   )
   


### PR DESCRIPTION
# Description

The automatically created PR looked like

```
    # Description
    Text here
```

which is wrong. The reason is, that `<<-` removes tabs only {and not spaces} and the IDE converts tabs into spaces automatically.

# Verification

Checked the output on my machine.