### PR TITLE
fix: move update script to correct location

### DIFF
--- a/.github/update_workflows.sh
+++ b/.github/update_workflows.sh
@@ -131,7 +131,7 @@ cp .github/workflows/default_* "$destination_path/.github/workflows"
 
 # move the update-workflows.sh script to the correct location (from older releases)
 if [ -f "$destination_path/update-workflows.sh" ]; then
-  git mv "$destination_path/update-workflows.sh" "$destination_path/.github/update_workflows.sh"
+  git mv -f "$destination_path/update-workflows.sh" "$destination_path/.github/update_workflows.sh"
 fi
 
 # we do not have special files for simple GitHub projects, this is handled by the default setup

--- a/.github/update_workflows.sh
+++ b/.github/update_workflows.sh
@@ -62,7 +62,7 @@ function create_commit_and_pr() {
     Done by the workflows in this feature branch, except for the release workflow.
 EOF
   )
-  
+
   gh pr create --title "ci: update workflows to latest version" --body "$body" --base main
   gh pr view --web
 }
@@ -128,6 +128,11 @@ shopt -s nullglob
 # basic setup for all types
 mkdir -p "$destination_path/.github/workflows"
 cp .github/workflows/default_* "$destination_path/.github/workflows"
+
+# move the update-workflows.sh script to the correct location (from older releases)
+if [ -f "$destination_path/update-workflows.sh" ]; then
+  git mv "$destination_path/update-workflows.sh" "$destination_path/.github/update_workflows.sh"
+fi
 
 # we do not have special files for simple GitHub projects, this is handled by the default setup
 if [ "$repository_type" != "github-only" ]; then


### PR DESCRIPTION
# Description

All `Repository-Template-*` repositories reference this script as `.github/update_workflows.sh`. We move the script to the correct location and provide an update mechanism in case the script is found in the wrong directory.

# Verification

Verified on my local machine.