### PR TITLE
feat: remove HTML comments from pull request body

### DIFF
--- a/.github/workflows/default_slash_ops_command_ready_callable.yml
+++ b/.github/workflows/default_slash_ops_command_ready_callable.yml
@@ -33,14 +33,17 @@ jobs:
             });
 
             // remove the checklist paragraph from "# Checklist" to the end of the PR text
-            const prTextWithoutChecklist = prText.split('\n').slice(0, prText.split('\n').
-                                             findIndex(line => line.startsWith('# Checklist'))).join('\n');
+            const cleanPrText = prText.split('\n').slice(0, prText.split('\n').
+                                  findIndex(line => line.startsWith('# Checklist'))).join('\n');
+
+            // remove HTML comments from the PR text
+            cleanPrText = cleanPrText.replace(/<!--[\s\S]*?-->/g, '');
 
             github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
-              body: prTextWithoutChecklist,
+              body: cleanPrText,
             });
 
             // set the PR to ready --> this is not possible with the GitHub API, use GraphQL instead


### PR DESCRIPTION
# Description

`/ready` prepares the PR for the review. Thus we should also remove the HTML comments from the PR body, usually Yamllint disable statements.