### PR TITLE
fix: use the correct dictionary

### DIFF
--- a/.config/dictionaries/project.txt
+++ b/.config/dictionaries/project.txt
@@ -1,6 +1,7 @@
 amannn
 aquasecurity
 buildx
+conventionalcommits
 cpus
 dockerhub
 dorny

--- a/.config/dictionaries/workflow.txt
+++ b/.config/dictionaries/workflow.txt
@@ -1,4 +1,3 @@
 codeowners
-conventionalcommits
 hapag
 nullglob

--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -222,9 +222,6 @@ fi
 # setup the release workflow
 if [ "$release_type" == "manual" ]; then
   rm .github/workflows/default*release*_callable.yml
-
-  # fix the dictionary
-  sed -i '/conventionalcommits/d' .config/dictionaries/workflows.txt
 fi
 
 #


### PR DESCRIPTION
# Description

Moves `conventionalcommits` to the internal dictionary as it is not copied to the target repository.