### PR TITLE
feat: add script to simulate the update

### DIFF
--- a/.config/dictionaries/project.txt
+++ b/.config/dictionaries/project.txt
@@ -1,6 +1,7 @@
 amannn
 aquasecurity
 buildx
+codeowners
 conventionalcommits
 cpus
 dockerhub

--- a/.config/dictionaries/workflow.txt
+++ b/.config/dictionaries/workflow.txt
@@ -1,3 +1,2 @@
-codeowners
-hapag
+Hapag
 nullglob

--- a/.github/workflows/scripts/check_dictionaries.sh
+++ b/.github/workflows/scripts/check_dictionaries.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
 #
 # Based on the idea outlined in https://github.com/streetsidesoftware/cspell/issues/2536#issuecomment-1126077282
 # but with a few modifications to fit the needs of our project.
 #
-
-set -euo pipefail
 
 MISSPELLED_WORDS_PATH="misspelled-words.txt"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+
+# output of simulate.sh
+simulate-*/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ marked with `USE_WORKFLOW` which are valid within this repository only.
 
 Make sure that this block is well formatted, otherwise the update script will fail in the related repository due to prettier.
 
+### Simulate the update
+
+Use the `simulate.sh` script to check the changes before applying them to the repository. The script
+
+- creates a new repository called `simulate-*` and applies the changes there
+- updates the `workflow.txt` dictionary in your current branch
+
 ### Spell Checker
 
 1. Add the words to the `.config/dictionaries/workflow.txt` file.

--- a/simulate.sh
+++ b/simulate.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+path=$(mktemp -d -t simulate-XXXXX -p .)
+
+echo "Creating a new repository in $path"
+git init "$path"
+
+cd "$path"
+cp ../update_workflows.sh .
+
+./update_workflows.sh github-only --force .
+
+eche "Creating the word list file"
+
+touch workflow.txt

--- a/simulate.sh
+++ b/simulate.sh
@@ -39,4 +39,6 @@ mv .config/cspell.json .config/cspell.json.temp
 cspell_version="v8.17.1"
 npx cspell@${cspell_version:1} . --dot --no-progress --no-summary --unique --words-only --no-exit-code --exclude ".git/**" --exclude ".idea/**" --exclude "$DICTIONARIES_PATH/**" | sort --ignore-case --unique > ../.config/dictionaries/workflow.txt
 
+mv .config/cspell.json.temp .config/cspell.json
+
 echo "Dictionary workflow.txt updated in your branch. Please review and commit the changes."

--- a/simulate.sh
+++ b/simulate.sh
@@ -1,16 +1,42 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+DICTIONARIES_PATH=".config/dictionaries"
+
 path=$(mktemp -d -t simulate-XXXXX -p .)
+path_origin=$(mktemp -d -t simulate-origin-XXXXX -p .)
+
+echo "Creating the remote repository in $path_origin"
+(
+  git init --initial-branch main "$path_origin"
+
+  cd "$path_origin"
+  touch README.md
+  git add README.md
+  git commit -m "xxx"
+)
 
 echo "Creating a new repository in $path"
-git init "$path"
+git init --initial-branch main "$path"
 
 cd "$path"
+git remote add origin "../$path_origin"
+git fetch origin main
+git checkout main
+
 cp ../update_workflows.sh .
 
-./update_workflows.sh github-only --force .
+./update_workflows.sh github-only --force . --dry-run --local-workflow-path ../
+# script is now located in .github/
+rm update_workflows.sh
 
-eche "Creating the word list file"
+echo "Creating the word list file"
 
-touch workflow.txt
+# don't use the cspell.json file to get the list of misspelled words we need to add to the dictionary
+mv .config/cspell.json .config/cspell.json.temp
+
+# renovate: datasource=github-releases depName=streetsidesoftware/cspell
+cspell_version="v8.17.1"
+npx cspell@${cspell_version:1} . --dot --no-progress --no-summary --unique --words-only --no-exit-code --exclude ".git/**" --exclude ".idea/**" --exclude "$DICTIONARIES_PATH/**" | sort --ignore-case --unique > ../.config/dictionaries/workflow.txt
+
+echo "Dictionary workflow.txt updated in your branch. Please review and commit the changes."


### PR DESCRIPTION
# Description

Adds `simulate.sh` to execute the workflow update in a temporary repository. This makes it possible to check the output of the script and determine the correct wordlist for the dictionary.

# Verification

Script locally tested.

