### PR TITLE
feat: do not allow duplicates in all dictionaries

### DIFF
--- a/.config/dictionaries/project.txt
+++ b/.config/dictionaries/project.txt
@@ -25,4 +25,3 @@ shellcheck
 shuf
 shunsuke
 temurin
-tfsec

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -17,9 +17,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: |
-          # create a dummy package.json file
-          echo "{}" > package.json
-
           # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
           cspell_dict_version="1.0.30"
           npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version}

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -22,11 +22,11 @@ jobs:
 
           # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
           cspell_dict_version="1.0.30"
-          npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version:1}
+          npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version}
 
           # renovate: datasource=npm depName=cspell
           cspell_version="8.17.3"
-          npx cspell@${cspell_version:1} . -c .config/cspell.json --dot
+          npx cspell@${cspell_version} . -c .config/cspell.json --dot
 
   validate-dictionaries:
     runs-on: ubuntu-latest

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -32,4 +32,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: .github/workflows/scripts/check_dictionaries.sh
-        if: steps.changes-for-shell.outputs.dictionaries == 'true'

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -31,4 +31,6 @@ jobs:
   validate-dictionaries:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - run: .github/workflows/scripts/check_dictionaries.sh

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - run: |
+          # create a dummy package.json file
+          echo "{}" > package.json
+
           # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
           cspell_dict_version="1.0.30"
           npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version:1}

--- a/.github/workflows/default_spelling_callable.yml
+++ b/.github/workflows/default_spelling_callable.yml
@@ -28,15 +28,5 @@ jobs:
   validate-dictionaries:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: changes-for-shell
-        with:
-          list-files: "shell"
-          filters: |
-            dictionaries:
-            - added|modified: '.config/dictionaries/*.txt'
-
       - run: .github/workflows/scripts/check_dictionaries.sh
         if: steps.changes-for-shell.outputs.dictionaries == 'true'

--- a/.github/workflows/scripts/check_dictionaries.sh
+++ b/.github/workflows/scripts/check_dictionaries.sh
@@ -19,12 +19,12 @@ jq 'del(.dictionaryDefinitions)' "${CSPELL_CONFIGURATION_FILE}.temp" | \
   jq 'del(.dictionaries)' > "$CSPELL_CONFIGURATION_FILE"
 
 # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
-cspell_dict_version="v1.0.29"
-npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version:1}
+cspell_dict_version="v1.0.30"
+npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version}
 
 # renovate: datasource=npm depName=cspell
-cspell_version="v8.17.1"
-npx cspell@${cspell_version:1} . -c "$CSPELL_CONFIGURATION_FILE" --dot --no-progress --no-summary --unique --words-only \
+cspell_version="8.17.3"
+npx cspell@${cspell_version} . -c "$CSPELL_CONFIGURATION_FILE" --dot --no-progress --no-summary --unique --words-only \
   --no-exit-code --exclude "$DICTIONARIES_PATH/**" | sort --ignore-case --unique > "$MISSPELLED_WORDS_PATH"
 
 # Check the custom dictionaries

--- a/.github/workflows/scripts/check_dictionaries.sh
+++ b/.github/workflows/scripts/check_dictionaries.sh
@@ -54,4 +54,9 @@ if [ $ONE_OR_MORE_FAILURES -ne "0" ]; then
   exit 1
 fi
 
+# check all dictionaries for duplicates
+echo "Checking all dictionaries for duplicates..."
+
+cat "${DICTIONARY_FILES_TO_CHECK[@]}" | sort --ignore-case | sort --unique --check
+
 echo "All dictionaries are valid."

--- a/.github/workflows/this_spelling.yml
+++ b/.github/workflows/this_spelling.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_spelling_callable.yml@kayma/no-duplicates
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_spelling_callable.yml@main
     secrets: inherit

--- a/.github/workflows/this_spelling.yml
+++ b/.github/workflows/this_spelling.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   default:
-    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_spelling_callable.yml@main
+    uses: Hapag-Lloyd/Workflow-Templates/.github/workflows/default_spelling_callable.yml@kayma/no-duplicates
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .idea/
 
+node_modules/
+package.json
+package-lock.json
+
 # output of simulate.sh
 simulate-*/

--- a/simulate.sh
+++ b/simulate.sh
@@ -44,12 +44,12 @@ jq 'del(.dictionaryDefinitions)' "${CSPELL_CONFIGURATION_FILE}.temp" | \
   jq 'del(.dictionaries)' > "$CSPELL_CONFIGURATION_FILE"
 
 # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
-cspell_dict_version="v1.0.29"
-npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version:1}
+cspell_dict_version="1.0.30"
+npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version}
 
 # renovate: datasource=github-releases depName=streetsidesoftware/cspell
-cspell_version="v8.17.1"
-npx cspell@${cspell_version:1} . -c "$CSPELL_CONFIGURATION_FILE" --dot --no-progress --no-summary --unique --words-only \
+cspell_version="8.17.3"
+npx cspell@${cspell_version} . -c "$CSPELL_CONFIGURATION_FILE" --dot --no-progress --no-summary --unique --words-only \
   --no-exit-code --exclude "$DICTIONARIES_PATH/**" | sed 's/.*/\L&/g' | sort --ignore-case --unique > ../.config/dictionaries/workflow.txt
 
 mv "${CSPELL_CONFIGURATION_FILE}.temp" "$CSPELL_CONFIGURATION_FILE"


### PR DESCRIPTION
# Description

As we have several dictionaries we want to ensure that a word does not appear in multiple dictionaries to keep them clean.

Also fixes:
- there is no prefix in NPM version numbers, so don't try to remove it as npm then can't install the requested version.
- always run the dictionary validation. Every change to the repository can result in orphaned words.
