### PR TITLE
fix: validate the dictionaries correctly

### DIFF
--- a/.github/workflows/scripts/check_dictionaries.sh
+++ b/.github/workflows/scripts/check_dictionaries.sh
@@ -15,8 +15,7 @@ export LC_ALL='C'
 
 # Make a list of every misspelled word without any custom dictionaries and configuration file
 cp "$CSPELL_CONFIGURATION_FILE" "${CSPELL_CONFIGURATION_FILE}.temp"
-jq 'del(.dictionaryDefinitions)' "${CSPELL_CONFIGURATION_FILE}.temp" | \
-  jq 'del(.dictionaries)' > "$CSPELL_CONFIGURATION_FILE"
+jq 'del(.dictionaries)' "${CSPELL_CONFIGURATION_FILE}.temp" > "$CSPELL_CONFIGURATION_FILE"
 
 # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
 cspell_dict_version="v1.0.30"

--- a/.github/workflows/scripts/check_dictionaries.sh
+++ b/.github/workflows/scripts/check_dictionaries.sh
@@ -18,7 +18,7 @@ cp "$CSPELL_CONFIGURATION_FILE" "${CSPELL_CONFIGURATION_FILE}.temp"
 jq 'del(.dictionaries)' "${CSPELL_CONFIGURATION_FILE}.temp" > "$CSPELL_CONFIGURATION_FILE"
 
 # renovate: datasource=npm depName=@cspell/dict-cspell-bundle
-cspell_dict_version="v1.0.30"
+cspell_dict_version="1.0.30"
 npm i -D @cspell/dict-cspell-bundle@${cspell_dict_version}
 
 # renovate: datasource=npm depName=cspell


### PR DESCRIPTION
# Description

We saw failing workflows complaining about

```
Checking for orphaned words in dictionary: .config/dictionaries/project.txt
The following word in the .config/dictionaries/project.txt dictionary is not being used: (boto)
The following word in the .config/dictionaries/project.txt dictionary is not being used: (botocore)
```

Not removing the `dictionaryDefinitions` resolves the problem, but I don't know, why. It seems that CSpell is working differently. Having `dictionaryDefinitions` without `dictionaries` shouldn't make a difference as `dictionaries` activates the usage of the definitions.