### PR TITLE
chore: set correct `semanticCommitType` for Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,16 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>Hapag-Lloyd/Renovate-Global-Configuration"],
+  packageRules: [
+    {
+      description: "GitHub Actions in this repo which are used for this repo",
+      matchFileNames: [".github/workflows/this_**"],
+      semanticCommitType: "ci",
+    },
+    {
+      description: "GitHub Actions templates. The real assets we develop in this repo.",
+      matchFileNames: ["!.github/workflows/this_**"],
+      semanticCommitType: "chore",
+    },
+  ],
 }


### PR DESCRIPTION
# Description

Set the correct title for pull requests generated by Renovate.

Standard workflow files should be updated with `ci: `, but the code we develop in this repository should show a `chore: ` as these files live in `.github/workflows` but are not directly used.