### PR TITLE
fix: do not move issues/pull requests to stale if labelled with `work-in-progress`

### DIFF
--- a/.github/workflows/default_stale_callable.yml
+++ b/.github/workflows/default_stale_callable.yml
@@ -22,6 +22,8 @@ jobs:
           stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days."
           close-issue-message: "This issue was closed because it has been stalled for 10 days with no activity."
           close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
+          exempt-issue-labels: "work-in-progress"
+          exempt-pr-labels: "work-in-progress"
           # yamllint enable rule:line-length
           days-before-stale: 30
           days-before-close: 10


### PR DESCRIPTION
# Description

The label `work-in-progress` was introduced to exempt issues and pull requests from the stale process. But the label was never respected.