### PR TITLE
feat: make the minimum Terraform version configurable

### DIFF
--- a/.config/dictionaries/workflow.txt
+++ b/.config/dictionaries/workflow.txt
@@ -1,5 +1,4 @@
 codeowners
-hapag
 infracost
 tflint
 tfsec

--- a/.github/workflows/terraform_module_terraform_callable.yml
+++ b/.github/workflows/terraform_module_terraform_callable.yml
@@ -5,6 +5,12 @@ name: Terraform
 on:
   # USE_WORKFLOW
   workflow_call:
+    inputs:
+      minimum-terraform-version:
+        type: string
+        required: false
+        default: "1.0.0"
+        description: "Minimum Terraform version to use for validation"
 # /USE_WORKFLOW
 # USE_REPOSITORY
 #  pull_request:
@@ -20,7 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform: [1.0.0, latest]
+        terraform:
+          - ${{ inputs.minimum-terraform-version }}
+          - latest
         directories: [".", "examples/cost", "examples/simple", "examples/full"]
     defaults:
       run:


### PR DESCRIPTION
# Description

Make the minimum Terraform version in the Workflows configurable by the user. It is not always possible to check against v1.0.0, especially if features from newer versions are used. The workflow fails in such cases.