### PR TITLE
fix: merge multiple `exempt-pr-labels` into one

### DIFF
--- a/.github/workflows/default_stale_callable.yml
+++ b/.github/workflows/default_stale_callable.yml
@@ -20,13 +20,12 @@ jobs:
           # yamllint disable rule:line-length
           stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days."
           stale-pr-message: "This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 10 days."
+          # yamllint enable rule:line-length
           close-issue-message: "This issue was closed because it has been stalled for 10 days with no activity."
           close-pr-message: "This PR was closed because it has been stalled for 10 days with no activity."
           exempt-issue-labels: "work-in-progress"
-          exempt-pr-labels: "work-in-progress"
-          # yamllint enable rule:line-length
+          exempt-pr-labels: "work-in-progress,dependency"
           days-before-stale: 30
           days-before-close: 10
-          exempt-pr-labels: "dependency"
           stale-issue-label: "stale"
           stale-pr-label: "stale"


### PR DESCRIPTION
# Description

Action failed with
```
[Invalid workflow file: .github/workflows/default_stale_callable.yml#L1](https://github.com/Hapag-Lloyd/Workflow-Templates/actions/runs/17458932822/workflow)
(Line: 30, Col: 11): 'exempt-pr-labels' is already defined
```
 as the `exempt-pr-labels` property was given twice.
