### PR TITLE
fix: set the version number in setup.cfg

### DIFF
--- a/.github/workflows/python_pypi_publish_callable.yml
+++ b/.github/workflows/python_pypi_publish_callable.yml
@@ -38,6 +38,11 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+      - name: Set version number
+        run: |
+          version="${GITHUB_REF#refs/tags\/}"
+          echo "Setting version in setup.cfg to ${version}"
+          sed -i "s/^version = .*/version = ${version}/" setup.cfg
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:


### PR DESCRIPTION
# Description

Checking PyPi I found out that there was only one release available. The problem is the version number in setup.cfg which was not incremented. This PR extracts the version number from the current tab and replaces the version number in setup.cfg.
