### PR TITLE
fix: create a release for all `chore` PRs

### DIFF
--- a/.release_github_only_auto/.releaserc.yml
+++ b/.release_github_only_auto/.releaserc.yml
@@ -28,7 +28,6 @@ analyzeCommits:
       - type: build
         release: false
       - type: chore
-        scope: deps
         release: patch
       - type: ci
         release: false


### PR DESCRIPTION
# Description

PRs with `chore:` were not released. The configuration expected the scope to be `deps` which makes no sense as we want to release all `chore:`.
